### PR TITLE
Add new Rust library to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ This suite is being used by:
 
 * [json-schema](https://github.com/hoxworth/json-schema)
 
+### Rust ###
+
+* [valico](https://github.com/rustless/valico)
+
 If you use it as well, please fork and send a pull request adding yourself to
 the list :).
 


### PR DESCRIPTION
There is [valico](https://github.com/rustless/valico) library which allows to validate JSON with JSON Schema v4.