### PR TITLE
Add test case for protocol-relative uri validation

### DIFF
--- a/tests/draft3/optional/format.json
+++ b/tests/draft3/optional/format.json
@@ -78,6 +78,11 @@
                 "valid": true
             },
             {
+                "description": "a valid protocol-relative URI",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
                 "description": "an invalid URI",
                 "data": "\\\\WINDOWS\\fileshare",
                 "valid": false

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -30,6 +30,11 @@
                 "valid": true
             },
             {
+                "description": "a valid protocol-relative URI",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
                 "description": "an invalid URI",
                 "data": "\\\\WINDOWS\\fileshare",
                 "valid": false


### PR DESCRIPTION
<https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-7.3.6> states that a valid URI is whatever is
defined by <https://tools.ietf.org/html/rfc3986>. According to section
4.2 (<https://tools.ietf.org/html/rfc3986#section-4.2>), these are valid
but "rarely used" (no longer true).

At least a PHP implementation didn't support this
(<https://github.com/justinrainbow/json-schema/issues/144>), and it is a
relative edge case so it seems useful to have a test for it.