### PR TITLE
JavaScript should be written in upper camel case

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This suite is being used by:
 
 * [json-schema-validator](https://github.com/fge/json-schema-validator)
 
-### Javascript ###
+### JavaScript ###
 
 * [json-schema-benchmark](https://github.com/Muscula/json-schema-benchmark)
 * [direct-schema](https://github.com/IreneKnapp/direct-schema)


### PR DESCRIPTION
Extremely pedantic, I know, but submitting anyway. JavaScript is officially spelled in upper camel case form.