### PR TITLE
Added information about npm package version of the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ This suite is being used by:
 * [jsen](https://github.com/bugventure/jsen)
 * [ajv](https://github.com/epoberezkin/ajv)
 
+### Node.js ###
+
+A [fork](https://github.com/atomiqio/json-schema-test-suite) of this repo has been published to [npm](https://www.npmjs.com/package/json-schema-test-suite).
+The package makes the JSON Schema Test Suite available to validator implementors without having to add a git submodule to their repo.
+
 ### .NET ###
 
 * [Newtonsoft.Json.Schema](https://github.com/JamesNK/Newtonsoft.Json.Schema)


### PR DESCRIPTION
This PR updates the README with a Node.js section that provides a link to an npm package of the JSON Schema Test Suite. The package facilitates testing by validator implementors without requiring that git submodule be added to their repositories.

Relates to Issue #96 